### PR TITLE
Changed header style to agree with LPSC 2019 template

### DIFF
--- a/lpscabs.sty
+++ b/lpscabs.sty
@@ -57,5 +57,5 @@
 
 \newcommand{\titlearea}[2]{%
 \thispagestyle{empty}
-\twocolumn[ {\textbf{\Large#1}} #2 ]
+\twocolumn[ {\textbf{\uppercase{#1}}} #2 \vspace{24pt}]
 }


### PR DESCRIPTION
Minor changes to lpscabs.sty
- Title is now always capitalized and in 10pt font type. This way the title from the LaTeX file can be spelled regularly (as required for the online form) and still comes out capitalized in the compiled version.
- 24pt spacing after the title before the 2 columns start. This is the same spacing as in the official Word template, 2 empty lines with 12pt spacing each.
- Checked margins and made sure they agree in size with the official 2019 Word template.